### PR TITLE
Add Education category to metainfo

### DIFF
--- a/com.endlessnetwork.aqueducts.appdata.xml
+++ b/com.endlessnetwork.aqueducts.appdata.xml
@@ -9,6 +9,7 @@
   <categories>
     <category>LearnToCode</category>
     <category>Game</category>
+    <category>Education</category>
   </categories>
   <developer_name>Endless Studios</developer_name>
   <url type="homepage">https://terminaltwo.com/home</url>


### PR DESCRIPTION
The listed `<categories>` have to be defined in the [freedesktop menu specification](https://specifications.freedesktop.org/menu-spec/latest/apas02.html). `LearnToCode` is not, which meant that outside of a forked Endless copy of gnome-software, the game wasn’t appearing in people’s app centres.

Fix that by adding categories which are defined in the specification. Keep `LearnToCode` for backwards compatibility with old versions of Endless gnome-software.